### PR TITLE
crud regle inscription

### DIFF
--- a/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/controller/RegleInscriptionController.java
+++ b/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/controller/RegleInscriptionController.java
@@ -72,7 +72,7 @@ public class RegleInscriptionController {
     @GetMapping("/edit/{id}")
     public String editForm(@PathVariable Long id, Model model) {
         RegleInscription regleInscription = regleInscriptionService.getById(id);
-        if (regleInscription == null) return "redirect:/profils";
+        if (regleInscription == null) return "redirect:/regle_inscription";
         model.addAttribute("regleInscription", regleInscription);
         model.addAttribute("profils" , profilService.getAll());
         model.addAttribute("page", "regle_inscription/form");

--- a/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/controller/RegleInscriptionController.java
+++ b/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/controller/RegleInscriptionController.java
@@ -1,0 +1,93 @@
+package com.bibliotheque.Bibliotheque.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import com.bibliotheque.Bibliotheque.model.RegleInscription;
+import com.bibliotheque.Bibliotheque.service.ProfilService;
+import com.bibliotheque.Bibliotheque.service.RegleInscriptionService;
+
+import jakarta.validation.Valid;
+
+@Controller
+@RequestMapping("/regles_inscription")
+public class RegleInscriptionController {
+
+    @Autowired
+    private RegleInscriptionService regleInscriptionService;
+
+    @Autowired
+    private ProfilService profilService; 
+    
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("reglesInscription", regleInscriptionService.getAll());
+        model.addAttribute("page", "regle_inscription/list");
+        return "template";
+    }
+
+    @GetMapping("/new")
+    public String createForm(Model model) {
+        model.addAttribute("regleInscription", new RegleInscription());
+        model.addAttribute("profils" , profilService.getAll());
+        model.addAttribute("page", "regle_inscription/form");
+        return "template";
+    }
+
+    @PostMapping
+    public String save(@Valid @ModelAttribute RegleInscription regleInscription, BindingResult result, Model model , RedirectAttributes redirectAttributes) {
+        if (result.hasErrors()) {
+            model.addAttribute("page", "regle_inscription/form");
+            return "template";
+        }
+        if(regleInscription.getId()!=null){
+            try {
+                regleInscriptionService.update(regleInscription);
+                redirectAttributes.addFlashAttribute("success", "Mis a jour reussi!");
+            } catch (Exception e) {
+                redirectAttributes.addFlashAttribute("error", "Erreur : " + e.getMessage());
+            }
+            
+        }else{
+            try {
+                regleInscriptionService.save(regleInscription);
+                redirectAttributes.addFlashAttribute("success", "Règle ajoutée avec succès !");
+            } catch (Exception e) {
+                redirectAttributes.addFlashAttribute("error", "Erreur : " + e.getMessage());
+            }
+        }
+        
+        
+        return "redirect:/regles_inscription";
+    }
+
+    @GetMapping("/edit/{id}")
+    public String editForm(@PathVariable Long id, Model model) {
+        RegleInscription regleInscription = regleInscriptionService.getById(id);
+        if (regleInscription == null) return "redirect:/profils";
+        model.addAttribute("regleInscription", regleInscription);
+        model.addAttribute("profils" , profilService.getAll());
+        model.addAttribute("page", "regle_inscription/form");
+        return "template";
+    }
+
+    @GetMapping("/delete/{id}")
+    public String delete(@PathVariable Long id , RedirectAttributes redirectAttributes) {
+        try {
+            redirectAttributes.addFlashAttribute("success", "Règle supprimer avec succès !");
+            regleInscriptionService.delete(id);
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("error", "Erreur : " + e.getMessage());
+        }
+        
+        return "redirect:/regles_inscription";
+    }
+}

--- a/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/controller/RegleInscriptionController.java
+++ b/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/controller/RegleInscriptionController.java
@@ -46,6 +46,7 @@ public class RegleInscriptionController {
     public String save(@Valid @ModelAttribute RegleInscription regleInscription, BindingResult result, Model model , RedirectAttributes redirectAttributes) {
         if (result.hasErrors()) {
             model.addAttribute("page", "regle_inscription/form");
+            model.addAttribute("profils" , profilService.getAll());
             return "template";
         }
         if(regleInscription.getId()!=null){

--- a/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/model/RegleInscription.java
+++ b/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/model/RegleInscription.java
@@ -6,6 +6,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 @Entity
 public class RegleInscription {
@@ -14,10 +16,12 @@ public class RegleInscription {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Min(value = 1, message = "La durée de validité doit être au minimum de 1")
     private int nbrValidite;
 
     @OneToOne
     @JoinColumn(name = "profil_id", referencedColumnName = "id", unique = true, nullable = false)
+    @NotNull(message = "Le profil est obligatoire")
     private Profil profil;
 
     public Long getId() {

--- a/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/model/RegleInscription.java
+++ b/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/model/RegleInscription.java
@@ -1,0 +1,48 @@
+package com.bibliotheque.Bibliotheque.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+
+@Entity
+public class RegleInscription {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int nbrValidite;
+
+    @OneToOne
+    @JoinColumn(name = "profil_id", referencedColumnName = "id", unique = true, nullable = false)
+    private Profil profil;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public int getNbrValidite() {
+        return nbrValidite;
+    }
+
+    public void setNbrValidite(int nbrValidite) {
+        this.nbrValidite = nbrValidite;
+    }
+
+    public Profil getProfil() {
+        return profil;
+    }
+
+    public void setProfil(Profil profil) {
+        this.profil = profil;
+    }
+
+    
+}

--- a/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/repository/RegleInscriptionRepository.java
+++ b/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/repository/RegleInscriptionRepository.java
@@ -1,0 +1,13 @@
+package com.bibliotheque.Bibliotheque.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bibliotheque.Bibliotheque.model.Profil;
+import com.bibliotheque.Bibliotheque.model.RegleInscription;
+
+public interface RegleInscriptionRepository extends JpaRepository<RegleInscription, Long> {
+
+    Optional<RegleInscription> findByProfil(Profil profil);
+}

--- a/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/service/RegleInscriptionService.java
+++ b/Bibliotheque/src/main/java/com/bibliotheque/Bibliotheque/service/RegleInscriptionService.java
@@ -1,0 +1,45 @@
+package com.bibliotheque.Bibliotheque.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.bibliotheque.Bibliotheque.model.RegleInscription;
+import com.bibliotheque.Bibliotheque.repository.RegleInscriptionRepository;
+
+@Service
+public class RegleInscriptionService {
+
+    @Autowired
+    private RegleInscriptionRepository regleInscriptionRepository;
+
+    public List<RegleInscription> getAll() {
+        return regleInscriptionRepository.findAll();
+    }
+
+    public void save(RegleInscription regleInscription) throws Exception{
+
+        if (regleInscriptionRepository.findByProfil(regleInscription.getProfil()).isPresent()) {
+            throw new Exception("Ce profil a déjà une règle d'inscription.");
+        }
+
+        try {
+            regleInscriptionRepository.save(regleInscription);
+        } catch (Exception e) {
+            throw new Exception("Erreur lors de l'enregistrement : " + e.getMessage());
+        }
+
+    }
+    public void update(RegleInscription regleInscription){
+        regleInscriptionRepository.save(regleInscription);
+    }
+
+    public RegleInscription getById(Long id) {
+        return regleInscriptionRepository.findById(id).orElse(null);
+    }
+
+    public void delete(Long id) {
+        regleInscriptionRepository.deleteById(id);
+    }
+}

--- a/Bibliotheque/src/main/resources/templates/regle_inscription/form.html
+++ b/Bibliotheque/src/main/resources/templates/regle_inscription/form.html
@@ -1,0 +1,24 @@
+<h2 th:text="${regleInscription.id == null ? 'Ajouter' : 'Modifier'} + ' une règle d\'inscription sur le profil'"></h2>
+
+<form th:action="@{/regles_inscription}" th:object="${regleInscription}" method="post">
+    <!-- Champ caché si modification -->
+    <input type="hidden" th:if="${regleInscription.id != null}" th:field="*{id}" />
+
+    <label for="profil">Profil :</label>
+    <select th:field="*{profil}" id="profil">
+        <option value="">Sélectionner un profil</option>
+        <option th:each="profil : ${profils}"
+                th:value="${profil.id}"
+                th:text="${profil.nom}">
+        </option>
+    </select>
+    <span th:errors="*{profil}" style="color:red"></span><br>
+
+    <label for="validite">Validité :</label>
+    <input type="text" th:field="*{nbrValidite}" id="validite" />
+    <span th:errors="*{nbrValidite}" style="color:red"></span><br>
+
+    <button type="submit">Valider</button>
+</form>
+
+<a th:href="@{/regles_inscription}">Retour à la liste</a>

--- a/Bibliotheque/src/main/resources/templates/regle_inscription/form.html
+++ b/Bibliotheque/src/main/resources/templates/regle_inscription/form.html
@@ -5,13 +5,21 @@
     <input type="hidden" th:if="${regleInscription.id != null}" th:field="*{id}" />
 
     <label for="profil">Profil :</label>
-    <select th:field="*{profil}" id="profil">
+
+    <!-- ✅ CAS 1 : Ajout (id == null) => on affiche la liste déroulante -->
+    <select th:if="${regleInscription.id == null}" th:field="*{profil}" id="profil">
         <option value="">Sélectionner un profil</option>
-        <option th:each="profil : ${profils}"
-                th:value="${profil.id}"
-                th:text="${profil.nom}">
+        <option th:each="profil : ${profils}" th:value="${profil.id}" th:text="${profil.nom}">
         </option>
     </select>
+
+    <!-- ✅ CAS 2 : Modification (id != null) => on affiche le nom du profil et un champ caché -->
+    <div th:if="${regleInscription.id != null}">
+        <span th:text="${regleInscription.profil.nom}">Nom du profil</span>
+        <!-- Champ caché pour conserver l'association Profil -->
+        <input type="hidden" th:field="*{profil}" />
+    </div>
+
     <span th:errors="*{profil}" style="color:red"></span><br>
 
     <label for="validite">Validité :</label>

--- a/Bibliotheque/src/main/resources/templates/regle_inscription/form.html
+++ b/Bibliotheque/src/main/resources/templates/regle_inscription/form.html
@@ -23,7 +23,7 @@
     <span th:errors="*{profil}" style="color:red"></span><br>
 
     <label for="validite">Validité :</label>
-    <input type="text" th:field="*{nbrValidite}" id="validite" />
+    <input type="number" th:field="*{nbrValidite}" id="validite" />
     <span th:errors="*{nbrValidite}" style="color:red"></span><br>
 
     <button type="submit">Valider</button>

--- a/Bibliotheque/src/main/resources/templates/regle_inscription/list.html
+++ b/Bibliotheque/src/main/resources/templates/regle_inscription/list.html
@@ -1,7 +1,7 @@
 <h2>Profils</h2>
 <a th:href="@{/regles_inscription/new}">Ajouter une profil</a>
 <table border="1">
-    <tr><th>Profil</th><th>Nombre de validiter</th></tr>
+    <tr><th>Profil</th><th>Nombre de validité</th></tr>
     <tr th:each="regleInscription : ${reglesInscription}">
         <td th:text="${regleInscription.profil.nom}"></td>
         <td th:text="${regleInscription.nbrValidite}"></td>

--- a/Bibliotheque/src/main/resources/templates/regle_inscription/list.html
+++ b/Bibliotheque/src/main/resources/templates/regle_inscription/list.html
@@ -1,0 +1,14 @@
+<h2>Profils</h2>
+<a th:href="@{/regles_inscription/new}">Ajouter une profil</a>
+<table border="1">
+    <tr><th>Profil</th><th>Nombre de validiter</th></tr>
+    <tr th:each="regleInscription : ${reglesInscription}">
+        <td th:text="${regleInscription.profil.nom}"></td>
+        <td th:text="${regleInscription.nbrValidite}"></td>
+        <td>
+            <a th:href="@{'/regles_inscription/edit/' + ${regleInscription.id}}">Modifier</a> |
+            <a th:href="@{'/regles_inscription/delete/' + ${regleInscription.id}}"
+               onclick="return confirm('Supprimer ?');">Supprimer</a>
+        </td>
+    </tr>
+</table>

--- a/Bibliotheque/src/main/resources/templates/template.html
+++ b/Bibliotheque/src/main/resources/templates/template.html
@@ -5,6 +5,11 @@
     <title>Bibliotheque</title>
 </head>
 <body>
+    <!-- Message de succès -->
+<div th:if="${success}" class="alert alert-success" th:text="${success}"></div>
+
+<!-- Message d'erreur -->
+<div th:if="${error}" class="alert alert-danger" th:text="${error}"></div>
     <h1>Template de base</h1>
     <div th:replace="~{${page}}"></div>
 </body>


### PR DESCRIPTION
## Résumé par Sourcery

Implémentation complète du support CRUD pour les règles d'inscription associées aux profils utilisateur, incluant la persistance, la validation, les workflows du contrôleur et les vues de l'interface utilisateur avec des messages flash.

Nouvelles fonctionnalités :
- Introduction de l'entité `RegleInscription` avec mapping JPA et repository
- Ajout d'une couche de service avec les opérations CRUD et la validation de profil unique pour les règles d'inscription
- Implémentation des endpoints du contrôleur pour lister, créer, modifier et supprimer les règles d'inscription
- Fourniture de templates Thymeleaf de liste et de formulaire pour la gestion des règles d'inscription
- Extension du template de base pour afficher les messages flash pour les résultats de succès et d'erreur

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement full CRUD support for registration rules associated with user profiles, including persistence, validation, controller workflows, and UI views with flash messaging.

New Features:
- Introduce RegleInscription entity with JPA mapping and repository
- Add service layer with CRUD operations and unique-profile validation for registration rules
- Implement controller endpoints to list, create, edit, and delete registration rules
- Provide Thymeleaf list and form templates for managing registration rules
- Extend base template to display flash messages for success and error outcomes

</details>